### PR TITLE
Rename find-package(kodi) to Kodi and get addon.xml inline with other add-ons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.6)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
-find_package(xbmc REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(OpenGL REQUIRED)
 
 add_definitions(-DHAS_SDL_OPENGL)

--- a/visualization.starburst/addon.xml.in
+++ b/visualization.starburst/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.starburst"
-  version="1.0.0"
+  version="1.1.0"
   name="StarBurst"
   provider-name="spiff">
   <extension

--- a/visualization.starburst/addon.xml.in
+++ b/visualization.starburst/addon.xml.in
@@ -6,11 +6,10 @@
   provider-name="spiff">
   <extension
     point="xbmc.player.musicviz"
-    library_linux="visualization.starburst.so"
-    library_osx="visualization.starburst.so"/>
+    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">StarBurst visualizer</summary>
     <description lang="en">StarBurst visualizer</description>
-    <platform>linux osx</platform>
+    <platform>@PLATFORM@</platform>
   </extension>
 </addon>


### PR DESCRIPTION
Package renaming is need after https://github.com/xbmc/xbmc/pull/9750 goes in.
The rest is to bring xml files up to par.