### PR TITLE
[Matrix] Fix debian build (libglm-dev was missing)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: kodi-visualization-starburst
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, kodi-addon-dev,
-               libgles2-mesa-dev [arm64 armhf], libgl1-mesa-dev [i386 amd64]
+               libgles2-mesa-dev [arm64 armhf], libgl1-mesa-dev [i386 amd64],
+               libglm-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://kodi.tv

--- a/visualization.starburst/addon.xml.in
+++ b/visualization.starburst/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.starburst"
-  version="2.1.0"
+  version="2.1.1"
   name="StarBurst"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Same as #8

To merge after xbmc/xbmc#16718