### PR TITLE
[Matrix|N*] copyright year increase and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](http://kodi.tv) visualization addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/visualization.starburst.svg?branch=Matrix)](https://travis-ci.org/xbmc/visualization.starburst/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.starburst?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=32&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.starburst/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.starburst/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.starburst?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-starburst?branch=Matrix) -->

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,7 +2,7 @@ Format: http://dep.debian.net/deps/dep5
 Upstream-Name: visualization.starburst
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/StarBurst.cpp
+++ b/src/StarBurst.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) Dinomight (dylan@castlegate.net)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/src/StarBurst.h
+++ b/src/StarBurst.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *  Copyright (C) Dinomight (dylan@castlegate.net)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later


### PR DESCRIPTION
- set copyright year to 2021
- remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.

After this comes new branch for Nexus two separate requests with version increases.