### PR TITLE
[Nexus] initial relase change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This is a [Kodi](http://kodi.tv) visualization addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.starburst?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=32&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.starburst/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.starburst/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.starburst?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-starburst?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.visualization.starburst?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=32&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/visualization.starburst/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fvisualization.starburst/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/visualization.starburst?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/visualization-starburst?branch=Nexus) -->
 
-![screenshot](https://raw.githubusercontent.com/xbmc/visualization.starburst/Matrix/visualization.starburst/resources/screenshot-01.jpg)
+![screenshot](https://raw.githubusercontent.com/xbmc/visualization.starburst/Nexus/visualization.starburst/resources/screenshot-01.jpg)
 
 ## Build instructions
 When building the addon you have to use the correct branch depending on which version of Kodi you're building against. 
@@ -20,7 +20,7 @@ The following instructions assume you will have built Kodi already in the `kodi-
 suggested by the README.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/xbmc/visualization.starburst.git`
+2. `git clone --branch Nexus https://github.com/xbmc/visualization.starburst.git`
 3. `cd visualization.starburst && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=visualization.starburst -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/visualization.starburst/addon.xml.in
+++ b/visualization.starburst/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.starburst"
-  version="2.4.0"
+  version="20.0.0"
   name="StarBurst"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.